### PR TITLE
Add chart showing cycles minted over time

### DIFF
--- a/components/Charts/LineChart.tsx
+++ b/components/Charts/LineChart.tsx
@@ -3,6 +3,7 @@ import { DateTime } from "luxon";
 import React, { useEffect, useRef } from "react";
 import useMeasure from "react-use-measure";
 import { formatNumber, formatNumberShortScale } from "../../lib/numbers";
+import WaterMark from "./WaterMark";
 
 const bisect = d3.bisector((d: { x: Date }) => d.x).center;
 
@@ -195,6 +196,7 @@ const LineChart = ({
           </div>
         </div>
       )}
+      <WaterMark />
       <svg width={width} height={height} ref={svgRef} />
     </div>
   ) : (

--- a/components/ChartsPages/ChartContainer.tsx
+++ b/components/ChartsPages/ChartContainer.tsx
@@ -1,0 +1,61 @@
+import Link from "next/link";
+import React from "react";
+import ContentLoader from "react-content-loader";
+import { FiChevronRight } from "react-icons/fi";
+import { ChartId } from "./ChartIds";
+
+type Props = {
+  chartId: ChartId;
+  isFull?: boolean;
+  heading: string;
+  dataKey: string;
+  isLoading: boolean;
+  children: React.ReactNode;
+};
+
+export const ChartContainer = ({
+  chartId,
+  isFull = false,
+  heading,
+  dataKey,
+  isLoading,
+  children,
+}: Props) => {
+  const height = isFull ? 400 : 250;
+  return (
+    <div className="bg-gray-100 dark:bg-gray-850 p-4 shadow-md rounded-md">
+      <div className="flex flex-col" style={{ minHeight: height }}>
+        {!isLoading ? (
+          <>
+            {!isFull && (
+              <Link href={`/charts/${chartId}`}>
+                <a className="font-bold link-overflow inline-flex items-center">
+                  {heading} <FiChevronRight />
+                </a>
+              </Link>
+            )}
+            {children}
+          </>
+        ) : (
+          <ContentLoader
+            uniqueKey={`charts.network-counts.${dataKey}`}
+            className="w-full"
+            width={100}
+            height={height}
+            viewBox={`0 0 100 ${height}`}
+            preserveAspectRatio="none"
+          >
+            {isFull ? (
+              <rect x="0" y="0" rx="2" ry="2" width="100%" height={height} />
+            ) : (
+              <>
+                <rect x="0" y="4" rx="2" ry="2" width="50%" height="16" />
+                <rect x="0" y="24" rx="2" ry="2" width="100%" height={height} />
+              </>
+            )}
+          </ContentLoader>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/components/ChartsPages/ChartIds.tsx
+++ b/components/ChartsPages/ChartIds.tsx
@@ -1,6 +1,7 @@
 import { CurveFactory, curveMonotoneX, curveStepAfter } from "d3";
 import { UseQueryResult } from "react-query";
 import useCanisterCounts from "../../lib/hooks/useCanisterCounts";
+import useMintedCycles from "../../lib/hooks/useMintedCycles";
 import useNetworkCounts from "../../lib/hooks/useNetworkCounts";
 import useTransactionCounts from "../../lib/hooks/useTransactionCounts";
 
@@ -12,7 +13,8 @@ export type ChartId =
   | "canisters"
   | "transactions"
   | "icp-burned"
-  | "icp-minted";
+  | "icp-minted"
+  | "cycles-minted";
 
 export type ChartType = {
   id: ChartId;
@@ -83,6 +85,13 @@ export const ChartTypes: ChartType[] = [
     id: "icp-minted",
     hook: useTransactionCounts,
     heading: "ICP Minted over Time",
+    dataKey: "minted",
+    curve: curveMonotoneX,
+  },
+  {
+    id: "cycles-minted",
+    hook: useMintedCycles,
+    heading: "Cycles Minted over Time",
     dataKey: "minted",
     curve: curveMonotoneX,
   },

--- a/components/ChartsPages/ChartIds.tsx
+++ b/components/ChartsPages/ChartIds.tsx
@@ -11,8 +11,8 @@ export type ChartId =
   | "providers"
   | "canisters"
   | "transactions"
-  | "burned"
-  | "minted";
+  | "icp-burned"
+  | "icp-minted";
 
 export type ChartType = {
   id: ChartId;
@@ -73,14 +73,14 @@ export const ChartTypes: ChartType[] = [
     heading: "ICP Transactions over Time",
   },
   {
-    id: "burned",
+    id: "icp-burned",
     hook: useTransactionCounts,
     heading: "ICP Burned over Time",
     dataKey: "burned",
     curve: curveMonotoneX,
   },
   {
-    id: "minted",
+    id: "icp-minted",
     hook: useTransactionCounts,
     heading: "ICP Minted over Time",
     dataKey: "minted",

--- a/components/ChartsPages/DataOverTimeChart.tsx
+++ b/components/ChartsPages/DataOverTimeChart.tsx
@@ -1,11 +1,9 @@
 import { DateTime } from "luxon";
-import Link from "next/link";
 import React, { useMemo } from "react";
-import ContentLoader from "react-content-loader";
-import { FiChevronRight } from "react-icons/fi";
 import { formatNumber } from "../../lib/numbers";
 import LineBarChart from "../Charts/LineBarChart";
 import { ChartId, ChartTypes } from "./ChartIds";
+import { ChartContainer } from "./ChartContainer";
 import TransactionsOverTimeChart from "./TransactionsOverTimeChart";
 
 const DataOverTimeChart = ({
@@ -42,54 +40,29 @@ const DataOverTimeChart = ({
         y2: sum,
       });
   }, [data]);
-  console.log(series);
 
   const height = isFull ? 400 : 250;
 
   return (
-    <div className="bg-gray-100 dark:bg-gray-850 p-4 shadow-md rounded-md">
-      <div className="flex flex-col" style={{ minHeight: height }}>
-        {data ? (
-          <>
-            {!isFull && (
-              <Link href={`/charts/${chartId}`}>
-                <a className="font-bold link-overflow inline-flex items-center">
-                  {heading} <FiChevronRight />
-                </a>
-              </Link>
-            )}
-            <LineBarChart
-              data={series}
-              xTooltipFormat={(x) =>
-                DateTime.fromJSDate(x).toLocaleString(DateTime.DATE_FULL)
-              }
-              y1TooltipFormat={({ y1 }) => `New: ${formatNumber(y1)}`}
-              y2TooltipFormat={({ y2 }) => `Total: ${formatNumber(y2)}`}
-              height={height}
-              curve={curve}
-            />
-          </>
-        ) : (
-          <ContentLoader
-            uniqueKey={`charts.network-counts.${dataKey}`}
-            className="w-full"
-            width={100}
-            height={height}
-            viewBox={`0 0 100 ${height}`}
-            preserveAspectRatio="none"
-          >
-            {isFull ? (
-              <rect x="0" y="0" rx="2" ry="2" width="100%" height={height} />
-            ) : (
-              <>
-                <rect x="0" y="4" rx="2" ry="2" width="50%" height="16" />
-                <rect x="0" y="24" rx="2" ry="2" width="100%" height={height} />
-              </>
-            )}
-          </ContentLoader>
-        )}
-      </div>
-    </div>
+  return (
+    <ChartContainer
+      chartId={chartId}
+      isFull={isFull}
+      heading={heading}
+      dataKey={dataKey}
+      isLoading={!data}
+    >
+      <LineBarChart
+        data={series}
+        xTooltipFormat={(x) =>
+          DateTime.fromJSDate(x).toLocaleString(DateTime.DATE_FULL)
+        }
+        y1TooltipFormat={({ y1 }) => `New: ${formatNumber(y1)}`}
+        y2TooltipFormat={({ y2 }) => `Total: ${formatNumber(y2)}`}
+        height={height}
+        curve={curve}
+      />
+    </ChartContainer>
   );
 };
 

--- a/components/ChartsPages/DataOverTimeChart.tsx
+++ b/components/ChartsPages/DataOverTimeChart.tsx
@@ -2,9 +2,12 @@ import { DateTime } from "luxon";
 import React, { useMemo } from "react";
 import { formatNumber } from "../../lib/numbers";
 import LineBarChart from "../Charts/LineBarChart";
+import LineChart from "../Charts/LineChart";
 import { ChartId, ChartTypes } from "./ChartIds";
 import { ChartContainer } from "./ChartContainer";
 import TransactionsOverTimeChart from "./TransactionsOverTimeChart";
+
+type Series = { x: Date; y1: number; y2: number };
 
 const DataOverTimeChart = ({
   chartId,
@@ -14,7 +17,7 @@ const DataOverTimeChart = ({
   isFull?: boolean;
 }) => {
   const { hook, dataKey, heading, curve } = ChartTypes.find(
-    ({ id }) => id === chartId
+    ({ id }) => id === chartId,
   );
 
   if (chartId === "transactions") {
@@ -23,7 +26,7 @@ const DataOverTimeChart = ({
 
   const { data } = hook();
 
-  const series = useMemo(() => {
+  const series: Series[] = useMemo(() => {
     let sum = 0;
     return data
       ?.map((d) => {
@@ -43,7 +46,22 @@ const DataOverTimeChart = ({
 
   const height = isFull ? 400 : 250;
 
-  return (
+  if (chartId === "cycles-minted") {
+    return (
+      <ChartContainer
+        chartId={chartId}
+        isFull={isFull}
+        heading={heading}
+        dataKey={dataKey}
+        isLoading={!data}
+      >
+        <LineChart
+          height={height}
+          data={series?.map((d) => ({ x: d.x, y: d.y2 }))}
+        />
+      </ChartContainer>
+    );
+  }
   return (
     <ChartContainer
       chartId={chartId}

--- a/components/ChartsPages/TransactionsOverTimeChart.tsx
+++ b/components/ChartsPages/TransactionsOverTimeChart.tsx
@@ -1,12 +1,10 @@
 import { curveMonotoneX } from "d3";
 import { DateTime } from "luxon";
-import Link from "next/link";
 import React, { useMemo } from "react";
-import ContentLoader from "react-content-loader";
-import { FiChevronRight } from "react-icons/fi";
 import useTransactionCounts from "../../lib/hooks/useTransactionCounts";
 import { formatNumber } from "../../lib/numbers";
 import MultiLineChart from "../Charts/MultiLineChart";
+import { ChartContainer } from "./ChartContainer";
 
 const TransactionsOverTimeChart = ({
   isFull = false,
@@ -33,57 +31,32 @@ const TransactionsOverTimeChart = ({
           }),
         ];
       },
-      [[], []]
+      [[], []],
     );
   }, [data]);
 
   const height = isFull ? 400 : 250;
 
   return (
-    <div className="bg-gray-100 dark:bg-gray-850 p-4 shadow-md rounded-md">
-      <div className="flex flex-col" style={{ minHeight: height }}>
-        {data ? (
-          <>
-            {!isFull && (
-              <Link href={`/charts/transactions`}>
-                <a className="font-bold link-overflow inline-flex items-center">
-                  {heading} <FiChevronRight />
-                </a>
-              </Link>
-            )}
-            <MultiLineChart
-              data={series}
-              xTooltipFormat={(x) =>
-                DateTime.fromJSDate(x).toLocaleString(DateTime.DATE_FULL)
-              }
-              yTooltipFormat={(i, { y }) =>
-                `${i === 0 ? "Count" : "Sum"}: ${formatNumber(y, 2)}`
-              }
-              height={height}
-              curve={curveMonotoneX}
-            />
-          </>
-        ) : (
-          <ContentLoader
-            uniqueKey={`charts.network-counts.transactions`}
-            className="w-full"
-            width={100}
-            height={height}
-            viewBox={`0 0 100 ${height}`}
-            preserveAspectRatio="none"
-          >
-            {isFull ? (
-              <rect x="0" y="0" rx="2" ry="2" width="100%" height={height} />
-            ) : (
-              <>
-                <rect x="0" y="4" rx="2" ry="2" width="50%" height="16" />
-                <rect x="0" y="24" rx="2" ry="2" width="100%" height={height} />
-              </>
-            )}
-          </ContentLoader>
-        )}
-      </div>
-    </div>
+    <ChartContainer
+      chartId={"transactions"}
+      isFull={isFull}
+      heading={heading}
+      dataKey={"transactions"}
+      isLoading={!data}
+    >
+      <MultiLineChart
+        data={series}
+        xTooltipFormat={(x) =>
+          DateTime.fromJSDate(x).toLocaleString(DateTime.DATE_FULL)
+        }
+        yTooltipFormat={(i, { y }) =>
+          `${i === 0 ? "Count" : "Sum"}: ${formatNumber(y, 2)}`
+        }
+        height={height}
+        curve={curveMonotoneX}
+      />
+    </ChartContainer>
   );
 };
 

--- a/lib/hooks/useMintedCycles.ts
+++ b/lib/hooks/useMintedCycles.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "react-query";
+import fetchJSON from "../fetch";
+
+type CyclesMintedCount = {
+  day: string;
+  minted: string;
+  id: string;
+};
+
+export default function useMintedCycles() {
+  return useQuery<CyclesMintedCount[]>(
+    "cycles/minted",
+    () => fetchJSON("/api/cycles/minted"),
+    {
+      staleTime: Infinity,
+      placeholderData: [],
+    },
+  );
+}


### PR DESCRIPTION
Fixes https://github.com/ic-rocks/ic-rocks/issues/14

The cycles minting canister does not store historical data on cycles minted, so we run a sync job to store this number daily.
We created a new chart to display cycles minted overtime.

This PR should be merged after https://github.com/ic-rocks/api/pull/2 is merged